### PR TITLE
heartbeat updated, fixed reconnection windown resending status

### DIFF
--- a/modules/RabbitMQClient.py
+++ b/modules/RabbitMQClient.py
@@ -24,7 +24,13 @@ class RabbitMQClient:
     def connect_to_rabbitmq(self):
         while True:
             try:
-                self.connection = pika.BlockingConnection(pika.ConnectionParameters(host=self.host))
+                self.connection = pika.BlockingConnection(
+                    pika.ConnectionParameters(
+                        host=self.host,
+                        heartbeat=30,  # Mantém a conexão ativa
+                        blocked_connection_timeout=7200  # Evita bloqueios longos
+                    )
+                )
                 self.channel = self.connection.channel()
 
                 self.channel.exchange_declare(exchange=self.task_exchange, exchange_type='direct', durable=True)
@@ -34,14 +40,13 @@ class RabbitMQClient:
 
                 self.channel.exchange_declare(exchange=self.status_exchange, exchange_type='direct', durable=True)
 
-                # 🛠 Permitir até 5 mensagens processadas ao mesmo tempo
-                self.channel.basic_qos(prefetch_count=5)
+                self.channel.basic_qos(prefetch_count=5)  # Para evitar sobrecarga
 
                 print(f"Connected to RabbitMQ - Task Exchange: {self.task_exchange}, Queue: {self.task_queue}")
-                break
+                return
             except pika.exceptions.AMQPConnectionError as e:
                 print(f"RabbitMQ connection failed: {e}. Retrying in 5 seconds...")
-                time.sleep(5)
+                time.sleep(5)  # Espera antes de tentar novamente
 
     def create_publisher_connection(self):
         """Cria uma conexão e canal separados para envio de mensagens."""
@@ -102,24 +107,27 @@ class RabbitMQClient:
             self.send_task_status(task_id, "FAILED")
 
     def send_task_status(self, task_id, status):
-        """Envia uma atualização de status da tarefa."""
-        try:
-            task_status_message = {
-                "taskId": task_id,
-                "status": status,
-                "updatedAt": datetime.now().isoformat()
-            }
+        """Envia uma atualização de status da tarefa, garantindo reenvio após reconexão."""
+        task_status_message = {
+            "taskId": task_id,
+            "status": status,
+            "updatedAt": datetime.now().isoformat()
+        }
 
-            self.publisher_channel.basic_publish(
-                exchange=self.status_exchange,
-                routing_key=self.status_routing_key,
-                body=json.dumps(task_status_message),
-                properties=pika.BasicProperties(content_type='application/json', delivery_mode=2)
-            )
-            print(f"Sent task status update: {task_status_message}")
-        except pika.exceptions.AMQPConnectionError as e:
-            print(f"Error sending status: {e}. Reconnecting...")
-            self.publisher_connection, self.publisher_channel = self.create_publisher_connection()
+        while True:  # Loop para tentar reconectar e reenviar a mensagem
+            try:
+                self.publisher_channel.basic_publish(
+                    exchange=self.status_exchange,
+                    routing_key=self.status_routing_key,
+                    body=json.dumps(task_status_message),
+                    properties=pika.BasicProperties(content_type='application/json', delivery_mode=2)
+                )
+                print(f"Sent task status update: {task_status_message}")
+                break  # Sai do loop se o envio for bem-sucedido
+            except pika.exceptions.AMQPConnectionError as e:
+                print(f"Error sending status: {e}. Reconnecting...")
+                self.publisher_connection, self.publisher_channel = self.create_publisher_connection()
+                time.sleep(2)  # Pequena espera antes de tentar novamente
 
     def close_connection(self):
         """Fecha conexões do RabbitMQ e encerra a thread pool."""


### PR DESCRIPTION
### Debug Description
RabbitMQClient.py resends the task status after reconnecting

### Why is this Feature Needed?
To not leave any message idling around

### Related Issue
<!-- Link to the related issue or user story (e.g., Resolves #123) -->
#61 
### Changes Made
<!-- List the changes or additions introduced by this feature -->
modules/RabbitMQClient.py
### How Has This Been Tested?
<!-- Detail how this feature has been tested, including test cases and environments -->
Making request with swagger

### Dependencies
<!-- List any dependencies (e.g., packages, APIs) that have been added or updated -->

### Checklist
- [x] Feature implemented as described
- [ ] Tests have been written or updated
- [ ] Documentation has been updated accordingly
- [x] Changes do not introduce any breaking changes

### Additional Context
<!-- Add any further context or considerations (e.g., performance impacts, future improvements) -->