### PR TITLE
Feature/implement reset definition

### DIFF
--- a/api/src/main/java/smartask/api/controllers/ClearAndResetController.java
+++ b/api/src/main/java/smartask/api/controllers/ClearAndResetController.java
@@ -29,4 +29,22 @@ public class ClearAndResetController {
         return "Todos os documentos da coleção 'schedules' foram deletados com sucesso.";
     }
 
+    @DeleteMapping("delete-reference-templates")
+    public String deleteAllReferenceTemplates() {
+        service.deleteAllReferenceTemplates();
+        return "Todos os documentos da coleção 'reference' foram deletados com sucesso.";
+    }
+
+    /**
+     * Endpoint para deletar todos os documentos da coleção "vacations".
+     */
+    @DeleteMapping("delete-vacation-templates")
+    public String deleteAllVacationTemplates() {
+        service.deleteAllVacationTemplates();
+        return "Todos os documentos da coleção 'vacations' foram deletados com sucesso.";
+    }
+
+
+
+
 }

--- a/api/src/main/java/smartask/api/controllers/ClearAndResetController.java
+++ b/api/src/main/java/smartask/api/controllers/ClearAndResetController.java
@@ -23,13 +23,13 @@ public class ClearAndResetController {
     /**
      * Endpoint para deletar todos os documentos da coleção "schedules".
      */
-    @DeleteMapping("delete-schedules")
+    @DeleteMapping("clean-schedules")
     public String deleteAllSchedules() {
         service.deleteAllSchedules();
         return "Todos os documentos da coleção 'schedules' foram deletados com sucesso.";
     }
 
-    @DeleteMapping("delete-reference-templates")
+    @DeleteMapping("clean-reference-templates")
     public String deleteAllReferenceTemplates() {
         service.deleteAllReferenceTemplates();
         return "Todos os documentos da coleção 'reference' foram deletados com sucesso.";
@@ -38,7 +38,7 @@ public class ClearAndResetController {
     /**
      * Endpoint para deletar todos os documentos da coleção "vacations".
      */
-    @DeleteMapping("delete-vacation-templates")
+    @DeleteMapping("clean-vacation-templates")
     public String deleteAllVacationTemplates() {
         service.deleteAllVacationTemplates();
         return "Todos os documentos da coleção 'vacations' foram deletados com sucesso.";

--- a/api/src/main/java/smartask/api/controllers/ClearAndResetController.java
+++ b/api/src/main/java/smartask/api/controllers/ClearAndResetController.java
@@ -1,0 +1,22 @@
+package smartask.api.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+import smartask.api.services.ClearAndResetService;
+
+@RestController
+@RequestMapping("clearnreset/")
+public class ClearAndResetController {
+
+    @Autowired
+    private ClearAndResetService service;
+
+    /**
+     * Endpoint para apagar e resetar os dados de funcionários e equipes.
+     */
+    @PostMapping("reset-employees-teams")
+    public String resetEmployeesAndTeams() {
+        service.clearAndResetData();
+        return "Dados de funcionários e equipes foram resetados com sucesso.";
+    }
+}

--- a/api/src/main/java/smartask/api/controllers/ClearAndResetController.java
+++ b/api/src/main/java/smartask/api/controllers/ClearAndResetController.java
@@ -19,4 +19,14 @@ public class ClearAndResetController {
         service.clearAndResetData();
         return "Dados de funcionários e equipes foram resetados com sucesso.";
     }
+
+    /**
+     * Endpoint para deletar todos os documentos da coleção "schedules".
+     */
+    @DeleteMapping("delete-schedules")
+    public String deleteAllSchedules() {
+        service.deleteAllSchedules();
+        return "Todos os documentos da coleção 'schedules' foram deletados com sucesso.";
+    }
+
 }

--- a/api/src/main/java/smartask/api/controllers/ClearAndResetController.java
+++ b/api/src/main/java/smartask/api/controllers/ClearAndResetController.java
@@ -3,41 +3,52 @@ package smartask.api.controllers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import smartask.api.services.ClearAndResetService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("clearnreset/")
+@Tag(name = "Clear and Reset", description = "Endpoints to clear or reset internal system data for testing or maintenance purposes")
 public class ClearAndResetController {
 
     @Autowired
     private ClearAndResetService service;
 
-    /**
-     * Endpoint para apagar e resetar os dados de funcionários e equipes.
-     */
+    @Operation(
+            summary = "Reset employees and teams",
+            description = "Deletes all current employees and teams, and recreates a default setup with teams 'Equipa A' and 'Equipa B' and 12 employees."
+    )
     @PostMapping("reset-employees-teams")
     public String resetEmployeesAndTeams() {
         service.clearAndResetData();
         return "Dados de funcionários e equipes foram resetados com sucesso.";
     }
 
-    /**
-     * Endpoint para deletar todos os documentos da coleção "schedules".
-     */
+    @Operation(
+            summary = "Delete all schedules",
+            description = "Removes all documents from the 'schedules' collection in the database."
+    )
     @DeleteMapping("clean-schedules")
     public String deleteAllSchedules() {
         service.deleteAllSchedules();
         return "Todos os documentos da coleção 'schedules' foram deletados com sucesso.";
     }
 
+    @Operation(
+            summary = "Delete all reference(minimuns and ideals) templates",
+            description = "Removes all documents from the 'reference templates' collection in the database."
+    )
     @DeleteMapping("clean-reference-templates")
     public String deleteAllReferenceTemplates() {
         service.deleteAllReferenceTemplates();
         return "Todos os documentos da coleção 'reference' foram deletados com sucesso.";
     }
 
-    /**
-     * Endpoint para deletar todos os documentos da coleção "vacations".
-     */
+
+    @Operation(
+            summary = "Delete all vacation templates",
+            description = "Removes all documents from the 'vacations' collection in the database."
+    )
     @DeleteMapping("clean-vacation-templates")
     public String deleteAllVacationTemplates() {
         service.deleteAllVacationTemplates();

--- a/api/src/main/java/smartask/api/controllers/EmployeesController.java
+++ b/api/src/main/java/smartask/api/controllers/EmployeesController.java
@@ -89,4 +89,19 @@ public class EmployeesController {
         employeeService.removeRestrictionFromEmployee(id, restrictionRequest.getRestrictionType(), restrictionRequest.getDate());
         return ResponseEntity.ok("Restriction deleted successfully");
     }
+
+    @Operation(summary = "Delete an employee by ID")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteEmployeeById(@PathVariable String id) {
+        employeeService.deleteEmployeeById(id);
+        return ResponseEntity.ok("Employee with ID " + id + " deleted successfully");
+    }
+
+    @Operation(summary = "Delete an employee by name")
+    @DeleteMapping("/by-name/{name}")
+    public ResponseEntity<String> deleteEmployeeByName(@PathVariable String name) {
+        employeeService.deleteEmployeeByName(name);
+        return ResponseEntity.ok("Employee with name '" + name + "' deleted successfully");
+    }
+
 }

--- a/api/src/main/java/smartask/api/controllers/ReferenceController.java
+++ b/api/src/main/java/smartask/api/controllers/ReferenceController.java
@@ -54,4 +54,12 @@ public class ReferenceController {
         referenceService.deleteTemplate(id);
         return ResponseEntity.noContent().build();
     }
+
+    @Operation(summary = "Excluir template de referência por nome")
+    @DeleteMapping("/by-name/{name}")
+    public ResponseEntity<Void> deleteTemplateByName(@PathVariable String name) {
+        referenceService.deleteTemplateByName(name);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/api/src/main/java/smartask/api/controllers/SchedulesController.java
+++ b/api/src/main/java/smartask/api/controllers/SchedulesController.java
@@ -142,4 +142,31 @@ public class SchedulesController {
         }
     }
 
+    @Operation(
+            summary = "Delete schedule by ID",
+            description = "Deletes the schedule with the specified ID if it exists."
+    )
+    @DeleteMapping("/delete/id/{id}")
+    public ResponseEntity<String> deleteById(@PathVariable String id) {
+        boolean deleted = service.deleteScheduleById(id);
+        if (deleted) {
+            return ResponseEntity.ok("Schedule with ID " + id + " deleted.");
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @Operation(
+            summary = "Delete schedule by title",
+            description = "Deletes the schedule with the specified title if it exists."
+    )
+    @DeleteMapping("/delete/title/{title}")
+    public ResponseEntity<String> deleteByTitle(@PathVariable String title) {
+        boolean deleted = service.deleteScheduleByTitle(title);
+        if (deleted) {
+            return ResponseEntity.ok("Schedule with title '" + title + "' deleted.");
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+
 }

--- a/api/src/main/java/smartask/api/controllers/VacationController.java
+++ b/api/src/main/java/smartask/api/controllers/VacationController.java
@@ -67,4 +67,25 @@ public class VacationController {
                 this.service.getAll()
         );
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteTemplateById(@PathVariable String id) {
+        try {
+            service.deleteTemplateById(id);
+            return ResponseEntity.ok("Template deletado com sucesso (ID: " + id + ")");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Erro ao deletar: " + e.getMessage());
+        }
+    }
+
+    @DeleteMapping("/by-name/{name}")
+    public ResponseEntity<String> deleteTemplateByName(@PathVariable String name) {
+        try {
+            service.deleteTemplateByName(name);
+            return ResponseEntity.ok("Template deletado com sucesso (nome: " + name + ")");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Erro ao deletar: " + e.getMessage());
+        }
+    }
+
 }

--- a/api/src/main/java/smartask/api/services/ClearAndResetService.java
+++ b/api/src/main/java/smartask/api/services/ClearAndResetService.java
@@ -1,0 +1,69 @@
+package smartask.api.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import smartask.api.models.Employee;
+import smartask.api.services.EmployeeService;
+import smartask.api.services.TeamService;
+import smartask.api.repositories.TeamRepository;
+import smartask.api.repositories.EmployeesRepository;
+
+import java.util.List;
+
+@Service
+public class ClearAndResetService {
+    @Autowired
+    private  TeamRepository teamRepository;
+    @Autowired
+    private  EmployeesRepository employeesRepository;
+    @Autowired
+    private  TeamService teamService;
+    @Autowired
+    private  EmployeeService employeeService;
+
+
+    /**
+     * Apaga todos os dados de equipes e funcionários e reseta a estrutura inicial.
+     */
+    public void clearAndResetData() {
+        // Apagar tudo
+        teamRepository.deleteAll();
+        employeesRepository.deleteAll();
+
+        // Criar Equipa A com 9 funcionários
+        teamService.addTeam("Equipa A");
+        for (int i = 1; i <= 9; i++) {
+            Employee employee = new Employee("Employee " + i);
+            employeeService.addEmployee(employee);
+        }
+        var aEmployees = employeeService.getEmployees().stream()
+                .filter(e -> e.getName().startsWith("Employee ") && Integer.parseInt(e.getName().split(" ")[1]) <= 9)
+                .map(Employee::getId)
+                .toList();
+        teamService.addEmployeesToTeam("Equipa A", aEmployees);
+
+        // Criar Equipa B com 3 funcionários
+        teamService.addTeam("Equipa B");
+        for (int i = 10; i <= 12; i++) {
+            Employee employee = new Employee("Employee " + i);
+            employeeService.addEmployee(employee);
+        }
+        var bEmployees = employeeService.getEmployees().stream()
+                .filter(e -> e.getName().startsWith("Employee ") && Integer.parseInt(e.getName().split(" ")[1]) >= 10)
+                .map(Employee::getId)
+                .toList();
+        teamService.addEmployeesToTeam("Equipa B", bEmployees);
+
+        // Adicionar Employee 5 e 6 à Equipa B (também estão na A)
+        employeeService.getEmployees().stream()
+                .filter(e -> e.getName().equals("Employee 5") || e.getName().equals("Employee 6"))
+                .map(Employee::getId)
+                .forEach(id -> teamService.addEmployeesToTeam("Equipa B", List.of(id)));
+
+        // Adicionar Employee 11 à Equipa A (também está na B)
+        employeeService.getEmployees().stream()
+                .filter(e -> e.getName().equals("Employee 11"))
+                .map(Employee::getId)
+                .forEach(id -> teamService.addEmployeesToTeam("Equipa A", List.of(id)));
+    }
+}

--- a/api/src/main/java/smartask/api/services/ClearAndResetService.java
+++ b/api/src/main/java/smartask/api/services/ClearAndResetService.java
@@ -3,11 +3,9 @@ package smartask.api.services;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import smartask.api.models.Employee;
-import smartask.api.repositories.SchedulesRepository;
+import smartask.api.repositories.*;
 import smartask.api.services.EmployeeService;
 import smartask.api.services.TeamService;
-import smartask.api.repositories.TeamRepository;
-import smartask.api.repositories.EmployeesRepository;
 
 import java.util.List;
 
@@ -23,7 +21,10 @@ public class ClearAndResetService {
     private  EmployeeService employeeService;
     @Autowired
     private SchedulesRepository schedulesRepository;
-
+    @Autowired
+    private ReferenceTemplateRepository referenceTemplateRepository;
+    @Autowired
+    private VacationTemplateRepository vacationTemplateRepository;
 
     /**
      * Apaga todos os dados de equipes e funcionários e reseta a estrutura inicial.
@@ -73,4 +74,20 @@ public class ClearAndResetService {
     public void deleteAllSchedules() {
         schedulesRepository.deleteAll();
     }
+
+    public void deleteAllReferenceTemplates() {
+        referenceTemplateRepository.deleteAll();
+    }
+
+
+
+    /**
+     * Apaga todos os documentos da coleção "vacations".
+     */
+    public void deleteAllVacationTemplates() {
+        vacationTemplateRepository.deleteAll();
+    }
+
+
+
 }

--- a/api/src/main/java/smartask/api/services/ClearAndResetService.java
+++ b/api/src/main/java/smartask/api/services/ClearAndResetService.java
@@ -3,6 +3,7 @@ package smartask.api.services;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import smartask.api.models.Employee;
+import smartask.api.repositories.SchedulesRepository;
 import smartask.api.services.EmployeeService;
 import smartask.api.services.TeamService;
 import smartask.api.repositories.TeamRepository;
@@ -20,6 +21,8 @@ public class ClearAndResetService {
     private  TeamService teamService;
     @Autowired
     private  EmployeeService employeeService;
+    @Autowired
+    private SchedulesRepository schedulesRepository;
 
 
     /**
@@ -65,5 +68,9 @@ public class ClearAndResetService {
                 .filter(e -> e.getName().equals("Employee 11"))
                 .map(Employee::getId)
                 .forEach(id -> teamService.addEmployeesToTeam("Equipa A", List.of(id)));
+    }
+
+    public void deleteAllSchedules() {
+        schedulesRepository.deleteAll();
     }
 }

--- a/api/src/main/java/smartask/api/services/EmployeeService.java
+++ b/api/src/main/java/smartask/api/services/EmployeeService.java
@@ -73,4 +73,21 @@ public class EmployeeService {
     public void saveEmployee(Employee employee) {
         repository.save(employee);
     }
+
+
+    public void deleteEmployeeById(String id) {
+        if (!repository.existsById(id)) {
+            throw new IllegalArgumentException("Employee with ID " + id + " not found.");
+        }
+        repository.deleteById(id);
+    }
+
+    public void deleteEmployeeByName(String name) {
+        Optional<Employee> optional = repository.findByName(name);
+        if (optional.isEmpty()) {
+            throw new IllegalArgumentException("Employee with name '" + name + "' not found.");
+        }
+        repository.delete(optional.get());
+    }
+
 }

--- a/api/src/main/java/smartask/api/services/ReferenceService.java
+++ b/api/src/main/java/smartask/api/services/ReferenceService.java
@@ -93,4 +93,11 @@ public class ReferenceService {
     public void deleteTemplate(String id) {
         repository.deleteById(id);
     }
+
+    public void deleteTemplateByName(String name) {
+        ReferenceTemplate template = repository.findByName(name)
+                .orElseThrow(() -> new NoSuchElementException("Template não encontrado com nome: " + name));
+        repository.delete(template);
+    }
+
 }

--- a/api/src/main/java/smartask/api/services/SchedulesService.java
+++ b/api/src/main/java/smartask/api/services/SchedulesService.java
@@ -89,4 +89,22 @@ public class SchedulesService {
     public Optional<Schedule> getScheduleById(String id) {
         return schedulerepository.findById(id);
     }
+
+    public boolean deleteScheduleById(String id) {
+        if (schedulerepository.existsById(id)) {
+            schedulerepository.deleteById(id);
+            return true;
+        }
+        return false;
+    }
+
+    public boolean deleteScheduleByTitle(String title) {
+        Optional<Schedule> schedule = schedulerepository.findByTitle(title);
+        if (schedule.isPresent()) {
+            schedulerepository.delete(schedule.get());
+            return true;
+        }
+        return false;
+    }
+
 }

--- a/api/src/main/java/smartask/api/services/VacationService.java
+++ b/api/src/main/java/smartask/api/services/VacationService.java
@@ -155,4 +155,15 @@ public class VacationService {
 
         return true;
     }
+
+    public void deleteTemplateById(String id) {
+        vacationTemplateRepository.deleteById(id);
+    }
+
+    public void deleteTemplateByName(String name) {
+        VacationTemplate template = vacationTemplateRepository.findByName(name)
+                .orElseThrow(() -> new NoSuchElementException("Template não encontrado com nome: " + name));
+        vacationTemplateRepository.delete(template);
+    }
+
 }


### PR DESCRIPTION
### Feature Description
Clear document and reset documents of employees-teams

### Why is this Feature Needed?
Overall usefully for development in general and usage of the application

### Related Issue
#134 

### Changes Made
In all api endpoints of schedules, vacation templates, minimuns template and employees
also added brand new endpoint to clean whole documents of schedules, vacation and minimuns and reset employee-teams configuration

### How Has This Been Tested?
Swagger

### Dependencies
None

### Checklist
- [ ] Feature implemented as described
- [ ] Tests have been written or updated
- [ ] Documentation has been updated accordingly
- [ ] Changes do not introduce any breaking changes

### Additional Context
<!-- Add any further context or considerations (e.g., performance impacts, future improvements) -->